### PR TITLE
Recover from goccy/go-yaml panic

### DIFF
--- a/content/content.go
+++ b/content/content.go
@@ -20,6 +20,12 @@ const (
 	FileTypeUnknown = "unknown"
 )
 
+func handlePanic(log *logrus.Logger) {
+	if r := recover(); r != nil {
+		log.Error("recovered from panic")
+	}
+}
+
 // IsJSON checks if the passed content of JSON.
 func IsJSON(content string) bool {
 	var js interface{}
@@ -35,15 +41,21 @@ func IsJSONString(content string) bool {
 }
 
 // IsYAML checks if the passed content of YAML.
-func IsYAML(content string) bool {
+func IsYAML(log *logrus.Logger, content string) bool {
 	var yml interface{}
+
+	// github.com/goccy/go-yaml can produce panics
+	defer handlePanic(log)
 
 	return yaml.Unmarshal([]byte(content), &yml) == nil
 }
 
 // IsYAMLString checks if the passed content of YAML string.
-func IsYAMLString(content string) bool {
+func IsYAMLString(log *logrus.Logger, content string) bool {
 	var yml string
+
+	// github.com/goccy/go-yaml can produce panics
+	defer handlePanic(log)
 
 	return yaml.Unmarshal([]byte(content), &yml) == nil
 }
@@ -66,7 +78,7 @@ func (obj Object) CheckFileType(log *logrus.Logger) string {
 	//	return FileTypeCSV
 	// }
 
-	if IsJSONString(string(obj)) || IsYAMLString(string(obj)) {
+	if IsJSONString(string(obj)) || IsYAMLString(log, string(obj)) {
 		log.Debug("input file type identified as string")
 
 		return FileTypeString
@@ -78,7 +90,7 @@ func (obj Object) CheckFileType(log *logrus.Logger) string {
 		return FileTypeJSON
 	}
 
-	if IsYAML(string(obj)) {
+	if IsYAML(log, string(obj)) {
 		log.Debug("input file type identified as YAML")
 
 		return FileTypeYAML


### PR DESCRIPTION
# The problem

`helm-images` produces a panic when extracting images from kyverno helm chart. The panic is caused by the underlying library `github.com/goccy/go-yaml` when evaluating kyverno config map data.

## helm-images version

```sh
$ helm images version
images version: {"version":"0.1.4","revision":"9f9c484de63f8ff7ab0bbb4ecda250d5b72a920c","environment":"production","build-date":"2024-03-17T08:55:09Z","go-version":"go1.22.0","platform":"darwin/arm64"}
```

## Test procedure

```sh
$ curl -sLO https://github.com/kyverno/kyverno/archive/refs/tags/kyverno-chart-3.1.1.tar.gz
$ tar xf kyverno-chart-3.1.1.tar.gz
$ cd cd kyverno-kyverno-chart-3.1.1/charts
$ helm images get kyverno
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x30 pc=0x101cdea08]

goroutine 1 [running]:
github.com/goccy/go-yaml.(*Decoder).nodeToValue(0x140001a8780, {0x102af0f00, 0x140000a6e00})
	github.com/goccy/go-yaml@v1.11.2/decode.go:306 +0x7e8
github.com/goccy/go-yaml.(*Decoder).nodeToValue(0x140001a8780, {0x102af0d80, 0x14000781c80})
	github.com/goccy/go-yaml@v1.11.2/decode.go:348 +0xa50
github.com/goccy/go-yaml.(*Decoder).parse(0x140001a8780, {0x140004b2000?, 0x102ac5ec0?, 0x140005d9440?})
	github.com/goccy/go-yaml@v1.11.2/decode.go:1650 +0xec
github.com/goccy/go-yaml.(*Decoder).decodeInit(0x140001a8780)
	github.com/goccy/go-yaml@v1.11.2/decode.go:1671 +0xa4
github.com/goccy/go-yaml.(*Decoder).DecodeContext(0x140001a8780, {0x102ae2a98, 0x103b08380}, {0x102685740?, 0x14000342780?})
	github.com/goccy/go-yaml@v1.11.2/decode.go:1719 +0x184
github.com/goccy/go-yaml.UnmarshalContext({0x102ae2a98, 0x103b08380}, {0x1400049aa00, 0x13b6, 0x1500}, {0x102685740, 0x14000342780}, {0x0, 0x0, 0x0})
	github.com/goccy/go-yaml@v1.11.2/yaml.go:191 +0x1f0
github.com/goccy/go-yaml.UnmarshalWithOptions(...)
	github.com/goccy/go-yaml@v1.11.2/yaml.go:185
github.com/goccy/go-yaml.Unmarshal(...)
	github.com/goccy/go-yaml@v1.11.2/yaml.go:179
github.com/nikhilsbhat/common/content.IsYAMLString({0x14000498000, 0x13b6})
	github.com/nikhilsbhat/common@v0.0.5-0.20240311153804-bae6b5bd313c/content/content.go:48 +0x80
github.com/nikhilsbhat/common/content.Object.CheckFileType({0x14000498000, 0x13b6}, 0x1400018fe80)
	github.com/nikhilsbhat/common@v0.0.5-0.20240311153804-bae6b5bd313c/content/content.go:69 +0xa8
github.com/nikhilsbhat/helm-images/pkg/k8s.(*ConfigMap).Get(0x140005fd440, {0x14000f82860, 0x17ea})
	github.com/nikhilsbhat/helm-images/pkg/k8s/k8s.go:406 +0x240
github.com/nikhilsbhat/helm-images/pkg.(*Images).GetImage(0x140005a0c80?, {0x140005a0f04?, 0x1023003a4?}, {0x14000f82860, 0x17ea})
	github.com/nikhilsbhat/helm-images/pkg/images.go:250 +0x5bc
github.com/nikhilsbhat/helm-images/pkg.(*Images).GetImages(0x103a96240)
	github.com/nikhilsbhat/helm-images/pkg/images.go:137 +0x484
github.com/nikhilsbhat/helm-images/cmd.getImagesCommand.func1(0x14000352608?, {0x140005da560?, 0x1?, 0x1022caebb?})
	github.com/nikhilsbhat/helm-images/cmd/register.go:72 +0x2c
github.com/spf13/cobra.(*Command).execute(0x14000352608, {0x140005da530, 0x1, 0x1})
	github.com/spf13/cobra@v1.8.0/command.go:983 +0x840
github.com/spf13/cobra.(*Command).ExecuteC(0x14000352c08)
	github.com/spf13/cobra@v1.8.0/command.go:1115 +0x344
github.com/nikhilsbhat/helm-images/cmd.execute(...)
	github.com/nikhilsbhat/helm-images/cmd/cmd.go:30
github.com/nikhilsbhat/helm-images/cmd.Main()
	github.com/nikhilsbhat/helm-images/cmd/cmd.go:21 +0x8c
main.main()
	github.com/nikhilsbhat/helm-images/main.go:8 +0x1c
Error: plugin "images" exited with error
```

## The fix

I've added panic recovery code on `IsYAML` and `IsYAMLString` functions. It would be best if `go-yaml` fixed their panic causing code (I've checked, they try to access properties on `nil` interfaces when parsing tokens) but this should be a good enough fix to prevent other code from crashing.

```sh
$ ./helm-images --skip-tests get /tmp/kyverno-kyverno-chart-3.1.1/charts/kyverno
WARN[0000] recovered from panic
WARN[0000] recovered from panic
ghcr.io/kyverno/kyverno:v1.11.1
ghcr.io/kyverno/kyvernopre:v1.11.1
ghcr.io/kyverno/background-controller:v1.11.1
ghcr.io/kyverno/cleanup-controller:v1.11.1
ghcr.io/kyverno/reports-controller:v1.11.1
bitnami/kubectl:1.26.10
bitnami/kubectl:1.26.4
bitnami/kubectl:1.28.4
bitnami/kubectl:1.26.4
```